### PR TITLE
Parametrize getDefaultButtonVariants function

### DIFF
--- a/frontend/src/animations.ts
+++ b/frontend/src/animations.ts
@@ -1,11 +1,17 @@
 import type { Variants, Easing } from 'motion/react';
 
-export function getDefaultButtonVariants(
-  disabled = false,
-  whileHover = 1.075,
-  whileTap = 0.965,
-  whileFocus = 1.075
-) {
+export function getDefaultButtonVariants(params?: {
+  disabled?: boolean;
+  whileHover?: number;
+  whileTap?: number;
+  whileFocus?: number;
+}) {
+  const {
+    disabled = false,
+    whileHover = 1.075,
+    whileTap = 0.965,
+    whileFocus = 1.075,
+  } = params ?? {};
   if (disabled) {
     return {};
   }

--- a/frontend/src/components/buttons/maximize-note.tsx
+++ b/frontend/src/components/buttons/maximize-note.tsx
@@ -23,7 +23,7 @@ export function MaximizeNoteButton({
           transition: { ease: easingFunctions['ease-out-quint'] },
         });
       }}
-      {...getDefaultButtonVariants(disabled)}
+      {...getDefaultButtonVariants({ disabled })}
       type="button"
       animate={{ rotate: isNoteMaximized ? 180 : 0 }}
     >

--- a/frontend/src/components/code/code-actions.tsx
+++ b/frontend/src/components/code/code-actions.tsx
@@ -41,7 +41,7 @@ export function CodeActions({
         setStatus={setStatus}
       />
       <MotionIconButton
-        {...getDefaultButtonVariants(false, 1.05, 0.975, 1.05)}
+        {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.975, whileFocus: 1.05 })}
         onClick={() => {
           setIsExpanded(!isExpanded);
         }}
@@ -49,7 +49,7 @@ export function CodeActions({
         {isExpanded ? <Minimize /> : <Maximize />}
       </MotionIconButton>
       <MotionIconButton
-        {...getDefaultButtonVariants(false, 1.05, 0.975, 1.05)}
+        {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.975, whileFocus: 1.05 })}
         onClick={() => {
           if (!codeMirrorInstance) return;
           const editorContent = codeMirrorInstance.view?.state.doc.toString();

--- a/frontend/src/components/code/delete-button.tsx
+++ b/frontend/src/components/code/delete-button.tsx
@@ -9,7 +9,7 @@ export function DeleteButton({ nodeKey }: { nodeKey: string }) {
 
   return (
     <MotionIconButton
-      {...getDefaultButtonVariants(false, 1.05, 0.975, 1.05)}
+      {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.975, whileFocus: 1.05 })}
       onClick={() => {
         lexicalEditor.update(() => {
           removeDecoratorNode(nodeKey);

--- a/frontend/src/components/code/play-button.tsx
+++ b/frontend/src/components/code/play-button.tsx
@@ -39,7 +39,7 @@ export function PlayButton({
 
   return (
     <MotionIconButton
-      {...getDefaultButtonVariants(false, 1.05, 0.975, 1.05)}
+      {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.975, whileFocus: 1.05 })}
       disabled={status === 'starting' || status === 'queueing'}
       onClick={() => {
         handleRunOrInterruptCode({

--- a/frontend/src/components/editor/toolbar/settings-dropdown.tsx
+++ b/frontend/src/components/editor/toolbar/settings-dropdown.tsx
@@ -39,7 +39,7 @@ export function SettingsDropdown({
     <div className="ml-auto flex flex-col" ref={dropdownContainerRef}>
       <MotionIconButton
         onClick={() => setIsOpen((prev) => !prev)}
-        {...getDefaultButtonVariants(isToolbarDisabled)}
+        {...getDefaultButtonVariants({ disabled: isToolbarDisabled })}
       >
         <HorizontalDots />
       </MotionIconButton>

--- a/frontend/src/components/folder-sidebar/folder-dialog-children.tsx
+++ b/frontend/src/components/folder-sidebar/folder-dialog-children.tsx
@@ -60,7 +60,7 @@ export function FolderDialogChildren({
         <DialogErrorText errorText={errorText} />
       </fieldset>
       <MotionButton
-        {...getDefaultButtonVariants(false, 1.05, 0.95, 1.05)}
+        {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.95, whileFocus: 1.05 })}
         className="w-[calc(100%-1.5rem)] mx-auto justify-center"
         type="submit"
       >

--- a/frontend/src/components/folder-sidebar/index.tsx
+++ b/frontend/src/components/folder-sidebar/index.tsx
@@ -80,7 +80,7 @@ export function FolderSidebar({ width }: { width: MotionValue<number> }) {
         <section className="px-2.5 pt-[1rem]">
           <SearchBar />
           <MotionButton
-            {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+            {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
             className="align-center mb-2 flex w-full justify-between bg-transparent"
             onClick={() =>
               setDialogData({

--- a/frontend/src/components/folder-sidebar/my-folders-accordion.tsx
+++ b/frontend/src/components/folder-sidebar/my-folders-accordion.tsx
@@ -75,7 +75,7 @@ export function MyFoldersAccordion({ folder }: { folder: string | undefined }) {
                   Something went wrong when fetching the folders
                 </p>
                 <MotionButton
-                  {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+                  {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
                   className="mx-2.5 flex text-center"
                   onClick={() => refetch()}
                 >

--- a/frontend/src/components/folder-sidebar/searchbar.tsx
+++ b/frontend/src/components/folder-sidebar/searchbar.tsx
@@ -7,7 +7,7 @@ import { navigate } from 'wouter/use-browser-location';
 export function SearchBar() {
   return (
     <motion.button
-      {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+      {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
       type="button"
       className="w-full mb-2.5 text-left flex items-center gap-2 text-zinc-600 dark:text-zinc-300 text-xs py-1.5 px-2 dark:bg-zinc-700 border-[1.25px] border-zinc-300 dark:border-zinc-600 rounded-md transition-colors"
       onClick={() => navigate(`/search`)}

--- a/frontend/src/components/inline-equation/index.tsx
+++ b/frontend/src/components/inline-equation/index.tsx
@@ -89,7 +89,7 @@ export function InlineEquation({
             editor={editor}
           >
             <motion.button
-              {...getDefaultButtonVariants(false, 1.115, 0.95, 1.115)}
+              {...getDefaultButtonVariants({ disabled: false, whileHover: 1.115, whileTap: 0.95, whileFocus: 1.115 })}
               type="button"
               onClick={() => setIsEditing(true)}
             >

--- a/frontend/src/components/note-component-container/component-controls.tsx
+++ b/frontend/src/components/note-component-container/component-controls.tsx
@@ -50,7 +50,7 @@ export function NoteComponentControls({
     >
       {buttonOptions?.trash?.enabled && (
         <motion.button
-          {...getDefaultButtonVariants(false, 1.115, 0.95, 1.115)}
+          {...getDefaultButtonVariants({ disabled: false, whileHover: 1.115, whileTap: 0.95, whileFocus: 1.115 })}
           type="button"
           onClick={() => {
             if (!nodeKey) {
@@ -68,7 +68,7 @@ export function NoteComponentControls({
 
       {buttonOptions?.fullscreen?.enabled && (
         <motion.button
-          {...getDefaultButtonVariants(false, 1.115, 0.95, 1.115)}
+          {...getDefaultButtonVariants({ disabled: false, whileHover: 1.115, whileTap: 0.95, whileFocus: 1.115 })}
           type="button"
           onClick={() => {
             // buttonOptions.fullscreen?.setIsExpanded(true);
@@ -87,7 +87,7 @@ export function NoteComponentControls({
       {children}
       {buttonOptions?.link?.enabled && (
         <motion.button
-          {...getDefaultButtonVariants(false, 1.115, 0.95, 1.115)}
+          {...getDefaultButtonVariants({ disabled: false, whileHover: 1.115, whileTap: 0.95, whileFocus: 1.115 })}
           type="button"
           onClick={() => {
             const src = buttonOptions.link?.src;

--- a/frontend/src/components/resize-container/resize-controls.tsx
+++ b/frontend/src/components/resize-container/resize-controls.tsx
@@ -57,7 +57,7 @@ export function ResizeControls({
       }}
     >
       <motion.button
-        {...getDefaultButtonVariants(false, 1.115, 0.95, 1.115)}
+        {...getDefaultButtonVariants({ disabled: false, whileHover: 1.115, whileTap: 0.95, whileFocus: 1.115 })}
         type="button"
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
           widthMotionValue.set('100%');

--- a/frontend/src/components/saved-search-page/index.tsx
+++ b/frontend/src/components/saved-search-page/index.tsx
@@ -72,7 +72,7 @@ export function SavedSearchPage({
                     Something went wrong when retrieving the search results
                   </p>
                   <MotionButton
-                    {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+                    {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
                     className="mx-2.5 flex text-center"
                     onClick={() => refetch()}
                   >

--- a/frontend/src/components/sync-changes-dialog/index.tsx
+++ b/frontend/src/components/sync-changes-dialog/index.tsx
@@ -68,7 +68,7 @@ export function SyncChangesDialog({
       <MotionButton
         type="submit"
         disabled={isPending}
-        {...getDefaultButtonVariants(isPending)}
+        {...getDefaultButtonVariants({ disabled: isPending })}
         className="ml-auto text-center flex justify-center w-48"
       >
         {isPending ? (

--- a/frontend/src/hooks/dialogs.tsx
+++ b/frontend/src/hooks/dialogs.tsx
@@ -53,7 +53,7 @@ export function useCreateNoteDialog(): (folder: string) => void {
             <DialogErrorText errorText={errorText} />
           </fieldset>
           <MotionButton
-            {...getDefaultButtonVariants(false, 1.05, 0.95, 1.05)}
+            {...getDefaultButtonVariants({ disabled: false, whileHover: 1.05, whileTap: 0.95, whileFocus: 1.05 })}
             className="w-[calc(100%-1.5rem)] mx-auto text-center justify-center"
             type="submit"
           >

--- a/frontend/src/routes/notes-sidebar/index.tsx
+++ b/frontend/src/routes/notes-sidebar/index.tsx
@@ -86,7 +86,7 @@ export function NotesSidebar({
                   </MotionIconButton>
                 </section>
                 <MotionButton
-                  {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+                  {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
                   onClick={() => openCreateNoteDialog(folder)}
                   className="align-center flex w-full justify-between bg-transparent mb-2"
                 >

--- a/frontend/src/routes/notes-sidebar/my-notes-sidebar.tsx
+++ b/frontend/src/routes/notes-sidebar/my-notes-sidebar.tsx
@@ -50,7 +50,7 @@ export function MyNotesSidebar({
             Something went wrong when retrieving the notes
           </p>
           <MotionButton
-            {...getDefaultButtonVariants(false, 1.025, 0.975, 1.025)}
+            {...getDefaultButtonVariants({ disabled: false, whileHover: 1.025, whileTap: 0.975, whileFocus: 1.025 })}
             className="mx-2.5 flex text-center"
             onClick={() => refetch()}
           >


### PR DESCRIPTION
Refactor `getDefaultButtonVariants` to accept an options object, improving parameter readability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-a21dd278-4b55-4e53-8c0f-73c9a8b04da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a21dd278-4b55-4e53-8c0f-73c9a8b04da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

