### PR TITLE
Refactor note title and optimistic rename

### DIFF
--- a/frontend/src/components/editor/index.tsx
+++ b/frontend/src/components/editor/index.tsx
@@ -122,7 +122,7 @@ export function NotesEditor({
               'max-w-[704px] mx-auto'
           )}
         >
-          <NoteTitle folder={folder} note={note} />
+          <NoteTitle filePath={new FilePath({ folder, note: `${note}.md` })} />
           <ComponentPickerMenuPlugin folder={folder} note={note} />
           <FilePickerMenuPlugin />
           {frontmatter.showTableOfContents === 'true' && (

--- a/frontend/src/routes/notes-sidebar/sidebar-button/index.tsx
+++ b/frontend/src/routes/notes-sidebar/sidebar-button/index.tsx
@@ -290,19 +290,18 @@ export function NoteSidebarButton({
                               return false;
                             }
 
-                            // Use the FilePath object for cleaner path handling
-                            const originalPath = `${sidebarNotePath.folder}/${sidebarNotePath.note}`;
-
-                            const targetFolder = sidebarNotePath.folder;
-                            const newPath = `${targetFolder}/${newFileName}.${sidebarNotePath.noteExtension}`;
-                            await renameFile({
-                              oldPath: originalPath,
-                              newPath: newPath,
+                            const originalFilePath = new FilePath({
+                              folder: sidebarNotePath.folder,
+                              note: sidebarNotePath.note,
+                            });
+                            const newFilePath = new FilePath({
+                              folder: sidebarNotePath.folder,
+                              note: `${newFileName}.${sidebarNotePath.noteExtension}`,
                             });
 
-                            const newFilePath = new FilePath({
-                              folder: targetFolder,
-                              note: `${newFileName}.${sidebarNotePath.noteExtension}`,
+                            await renameFile({
+                              oldPath: originalFilePath,
+                              newPath: newFilePath,
                             });
 
                             navigate(newFilePath.getLinkToNote());

--- a/internal/services/note_service.go
+++ b/internal/services/note_service.go
@@ -71,37 +71,7 @@ func (n *NoteService) GetNotes(folderName string, sortOption string) config.Back
 	}
 }
 
-// RenameNote renames a note file within a folder from oldNoteTitle to newNoteTitle (both without extension).
-// Returns a BackendResponseWithoutData indicating success or failure.
-func (n *NoteService) RenameNote(folderName string, oldNoteTitle string, newNoteTitle string) config.BackendResponseWithoutData {
-	noteBase := filepath.Join(n.ProjectPath, "notes", folderName)
-	pathToNewNote := filepath.Join(noteBase, newNoteTitle+".md")
-	doesExist, err := util.FileOrFolderExists(
-		pathToNewNote,
-	)
-
-	if err != nil {
-		return config.BackendResponseWithoutData{Success: false, Message: err.Error()}
-	}
-
-	if doesExist {
-		return config.BackendResponseWithoutData{
-			Success: false,
-			Message: fmt.Sprintf("%s already exists in /%s", newNoteTitle, folderName),
-		}
-	}
-
-	// Rename the markdown file to match the new note title
-	err = os.Rename(
-		filepath.Join(noteBase, fmt.Sprintf("%s.md", oldNoteTitle)),
-		filepath.Join(noteBase, fmt.Sprintf("%s.md", newNoteTitle)),
-	)
-	if err != nil {
-		return config.BackendResponseWithoutData{Success: false, Message: err.Error()}
-	}
-
-	return config.BackendResponseWithoutData{Success: true, Message: "Note renamed successfully"}
-}
+// Deprecated: RenameNote has been removed in favor of RenameFile.
 
 // RenameFile renames a file from oldFolderNotePath to newFolderNotePath.
 // Both paths should be relative to the notes directory (e.g., "folder/note.ext").


### PR DESCRIPTION
Refactor note renaming to use an optimistic `useRenameFileMutation` and remove the deprecated `RenameNote` backend function to simplify frontend logic and prevent 404 redirects.

The previous implementation of renaming a note would navigate to the new URL *after* the backend call completed. If the backend call was slow, the user would briefly see a 404 page because the cache was not updated yet. Making `useRenameFileMutation` optimistic ensures the frontend cache is updated immediately, allowing navigation to the new path without a 404.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc3bdc9b-6c8e-448f-9b9d-eb842782fd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc3bdc9b-6c8e-448f-9b9d-eb842782fd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

