### PR TITLE
Preserve file extensions in truncated note titles

### DIFF
--- a/frontend/src/routes/notes-sidebar/sidebar-button/card-note-sidebar-item.tsx
+++ b/frontend/src/routes/notes-sidebar/sidebar-button/card-note-sidebar-item.tsx
@@ -45,11 +45,14 @@ export function CardNoteSidebarItem({
         <div className={cn('w-full', doesHaveImage && 'w-[calc(100%-52px)]')}>
           <p
             className={cn(
-              'whitespace-nowrap pointer-events-none text-ellipsis overflow-hidden',
+              'pointer-events-none flex min-w-0',
               isSelected && 'text-white!'
             )}
           >
-            {sidebarNoteNameWithoutExtension}.{sidebarNoteExtension}
+            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+              {sidebarNoteNameWithoutExtension}
+            </span>
+            <span className="shrink-0">.{sidebarNoteExtension}</span>
           </p>
           <p
             className={cn(

--- a/frontend/src/routes/notes-sidebar/sidebar-button/list-note-sidebar-item.tsx
+++ b/frontend/src/routes/notes-sidebar/sidebar-button/list-note-sidebar-item.tsx
@@ -18,8 +18,11 @@ export function ListNoteSidebarItem({
         fileExtension={sidebarNoteExtension}
         noteNameWithExtension={activeNoteNameWithExtension}
       />
-      <p className="whitespace-nowrap pointer-events-none text-ellipsis overflow-hidden">
-        {sidebarNoteNameWithoutExtension}.{sidebarNoteExtension}
+      <p className="pointer-events-none flex min-w-0">
+        <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+          {sidebarNoteNameWithoutExtension}
+        </span>
+        <span className="shrink-0">.{sidebarNoteExtension}</span>
       </p>
     </>
   );


### PR DESCRIPTION
Ensure file extensions are not truncated in the note sidebar by applying ellipsis only to the filename basename.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7110e9a-b3a8-44db-9b7c-c553bb1e75c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7110e9a-b3a8-44db-9b7c-c553bb1e75c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure note file extensions remain visible in the sidebar by ellipsizing only the basename using a flex/span layout.
> 
> - **Frontend — Notes Sidebar**:
>   - **Title rendering**:
>     - In `card-note-sidebar-item.tsx` and `list-note-sidebar-item.tsx`, split note title into basename (ellipsized) and extension (non-shrinking) using `flex` with `min-w-0`.
>     - Adjust classes to prevent truncation of `.{extension}` while keeping basename overflow-ellipsis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b78dbf0d62d2cf750e7c07611690ef0c55b1d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->